### PR TITLE
Remove dependency on Open-SSL

### DIFF
--- a/SPLMimeEntity.podspec
+++ b/SPLMimeEntity.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.license      = 'MIT'
   s.authors          = { "Oliver Letterer" => "oliver.letterer@gmail.com" }
   s.social_media_url = "http://twitter.com/oletterer"
-  s.platform     = :ios, '6.0'
+  s.platform     = :ios, '7.0'
   s.source       = { :git => "https://github.com/OliverLetterer/SPLMimeEntity.git", :tag => s.version.to_s }
   s.source_files  = 'SPLMimeEntity'
   s.dependency 'mimetic', '~> 0.9.7'

--- a/SPLMimeEntity.podspec
+++ b/SPLMimeEntity.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SPLMimeEntity"
-  s.version      = "1.0.0"
+  s.version      = "1.0.1"
   s.summary      = "Parsing EML files."
   s.description  = "Objective-C binding to mimetic."
   s.homepage     = "https://github.com/OliverLetterer/SPLMimeEntity"
@@ -11,6 +11,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/OliverLetterer/SPLMimeEntity.git", :tag => s.version.to_s }
   s.source_files  = 'SPLMimeEntity'
   s.dependency 'mimetic', '~> 0.9.7'
-  s.dependency 'CTOpenSSLWrapper', '~> 1.2.0'
   s.requires_arc = true
 end

--- a/SPLMimeEntity/SPLMimeEntity.mm
+++ b/SPLMimeEntity/SPLMimeEntity.mm
@@ -7,7 +7,6 @@
 //
 
 #import "SPLMimeEntity.h"
-#import <NSString+CTOpenSSL.h>
 
 #include <iostream>
 #include <mimetic/mimetic.h>
@@ -27,7 +26,7 @@ inline NSString *MimeEntityGetHeaderValue(MimeEntity *mimeEntity, NSString *head
 static NSData *dataFromStringWithEncoding(NSString *bodyString, NSString *encoding)
 {
     if ([encoding.lowercaseString isEqualToString:@"base64"]) {
-        return [bodyString dataFromBase64EncodedString];
+        return [[bodyString dataUsingEncoding:NSUTF8StringEncoding] base64EncodedDataWithOptions:0];
     } else {
         if ([encoding rangeOfString:@"quoted-printable"].length > 0) {
             bodyString = [bodyString stringByReplacingOccurrencesOfString:@"=\r\n" withString:@""];


### PR DESCRIPTION
Open SSL is a pretty big library, and we're just using it for Base-64... Fortunately iOS 7 > has the API we were missing, and with it the dependency on CTOpenSSLWrapper can be removed.
